### PR TITLE
DOR-2251: Use UnixNano() instead of Unix()

### DIFF
--- a/session/sess_cookie.go
+++ b/session/sess_cookie.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 )
 
 var cookiepder = &CookieProvider{}
@@ -131,7 +132,7 @@ func (pder *CookieProvider) SessionInit(maxlifetime int64, config string) error 
 	if err != nil {
 		return err
 	}
-	pder.maxlifetime = maxlifetime
+	pder.maxlifetime = maxlifetime * int64(time.Second)
 	return nil
 }
 

--- a/session/sess_test.go
+++ b/session/sess_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/aes"
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func Test_gob(t *testing.T) {
@@ -74,8 +75,9 @@ func TestCookieEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Fatal("encodeCookie:", err)
 	}
+	gcmaxlifetime = 3600 * int64(time.Second)
 	dst := make(map[interface{}]interface{})
-	dst, err = decodeCookie(block, hashKey, securityName, str, 3600)
+	dst, err = decodeCookie(block, hashKey, securityName, str, gcmaxlifetime)
 	if err != nil {
 		t.Fatal("decodeCookie", err)
 	}

--- a/session/sess_utils.go
+++ b/session/sess_utils.go
@@ -128,7 +128,7 @@ func encodeCookie(block cipher.Block, hashKey, name string, value map[interface{
 	}
 	b = encode(b)
 	// 3. Create MAC for "name|date|value". Extra pipe to be used later.
-	b = []byte(fmt.Sprintf("%s|%d|%s|", name, time.Now().UTC().Unix(), b))
+	b = []byte(fmt.Sprintf("%s|%d|%s|", name, time.Now().UTC().UnixNano(), b))
 	h := hmac.New(sha1.New, []byte(hashKey))
 	h.Write(b)
 	sig := h.Sum(nil)
@@ -164,7 +164,10 @@ func decodeCookie(block cipher.Block, hashKey, name, value string, gcmaxlifetime
 	if t1, err = strconv.ParseInt(string(parts[0]), 10, 64); err != nil {
 		return nil, errors.New("Decode: invalid timestamp")
 	}
-	t2 := time.Now().UTC().Unix()
+	t2 := time.Now().UTC().UnixNano()
+	if t1 > t2 {
+		return nil, errors.New("Decode: timestamp is too new")
+	}
 	if t1 < t2-gcmaxlifetime {
 		return nil, errors.New("Decode: expired timestamp")
 	}


### PR DESCRIPTION
This PR reverts #2 and provides a better long term solution by increasing the time resolution to avoid `Decode: timestamp is too new` errors when multiple server serving beego content.

Fixed unit test.